### PR TITLE
Fix 'E684: list index out of range: 1' error

### DIFF
--- a/autoload/gitblame.vim
+++ b/autoload/gitblame.vim
@@ -33,7 +33,7 @@ function! s:system(str, ...)
 endfunction
 
 function! gitblame#commit_summary(file, line)
-    let git_blame = split(s:system('git --no-pager blame '.a:file.' -L '.a:line.',+1 --porcelain'), "\n")
+    let git_blame = split(s:system('cd `dirname '.a:file.'`; git --no-pager blame '.a:file.' -L '.a:line.',+1 --porcelain'), "\n")
     let l:shell_error = s:has_vimproc() ? vimproc#get_last_status() : v:shell_error
     if l:shell_error && git_blame[0] =~# '^fatal: Not a git repository'
         return 'Error: Not a git repository'


### PR DESCRIPTION
Change to files directory before calling git blame. This is required to
avoid errors while editing files in a git repository from outside a git
repository or to edit files in a different repository.